### PR TITLE
Changed adapter macro to dispatch in macros

### DIFF
--- a/macros/convert_timezone.sql
+++ b/macros/convert_timezone.sql
@@ -1,5 +1,5 @@
 {%- macro convert_timezone(source_timezone, target_timezone, ts) -%}
-  {{ adapter_macro('datateer.convert_timezone', source_timezone, target_timezone, ts) }}
+  {{ adapter.dispatch('convert_timezone','datateer')(source_timezone, target_timezone, ts) }}
 {%- endmacro -%}
 
 

--- a/macros/datediff.sql
+++ b/macros/datediff.sql
@@ -1,5 +1,5 @@
 {%- macro datediff(first_date, second_date, datepart) -%}
-  {{ adapter_macro('datateer.datediff', first_date, second_date, datepart) }}
+  {{ adapter.dispatch('datediff', 'datateer')(first_date, second_date, datepart) }}
 {%- endmacro -%}
 {%- macro default__datediff(datepart, first_date, second_date) -%}
     datediff('{{ datepart }}', {{ first_date }}, {{ second_date }})

--- a/macros/getdate.sql
+++ b/macros/getdate.sql
@@ -1,5 +1,5 @@
 {%- macro getdate() -%}
-  {{ adapter_macro('datateer.getdate') }}
+  {{ adapter.dispatch('getdate','datateer')() }}
 {%- endmacro -%}
 
 

--- a/macros/try_cast.sql
+++ b/macros/try_cast.sql
@@ -1,5 +1,5 @@
 {%- macro try_cast(datatype, str) -%}
-  {{ adapter_macro('datateer.try_cast', datatype, str) }}
+  {{ adapter.dispatch('try_cast', 'datateer')(datatype, str) }}
 {%- endmacro -%}
 
 


### PR DESCRIPTION
Changed macros that used adapter_macro to adapter.dispatch.  I tested the change on the try-cast macro but was not able to figure out a way to test it with the others.  I especially am not sure about the get-date macro that does not have any arguments.  